### PR TITLE
Add Dockerfile for clypd js environment

### DIFF
--- a/images/clypd-env/Dockerfile
+++ b/images/clypd-env/Dockerfile
@@ -1,0 +1,14 @@
+# Copied and modified from ../js/Dockerfile-8.x
+FROM clyphub/js-env:chromium
+
+WORKDIR /usr/src/app
+ENV NODE_VERSION=8.10.0-1
+
+# build-essential and git are required to build some of our module dependencies
+RUN apt-get install -y \
+	build-essential \
+	git \
+	gpg \
+    && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+    && apt-get install -y nodejs=${NODE_VERSION}nodesource1 gpg \
+    && rm -rf /var/lib/apt/lists


### PR DESCRIPTION
Adds a base image contain build dependencies for our js environment for us in system integration testing.

Includes
* Chromium
* Node
* npm
* various other build dependencies like git, make, gcc

Other work includes building & pushing base images to new dockerhub repo: https://hub.docker.com/r/clyphub/js-env/tags/

MAIN-28142