### PR TITLE
MAIN-37981 Update docker to new Node version

### DIFF
--- a/images/clypd-env/Dockerfile
+++ b/images/clypd-env/Dockerfile
@@ -2,13 +2,13 @@
 FROM clyphub/js-env:chromium
 
 WORKDIR /usr/src/app
-ENV NODE_VERSION=8.10.0-1
+ENV NODE_VERSION=10.12.0
 
 # build-essential and git are required to build some of our module dependencies
 RUN apt-get install -y \
 	build-essential \
 	git \
 	gpg \
-    && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+    && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
     && apt-get install -y nodejs=${NODE_VERSION}nodesource1 gpg \
     && rm -rf /var/lib/apt/lists


### PR DESCRIPTION
This commit updates our JS ENV Dockerfile to use Node version 10.12.0 (the same version as the UI app now uses). Once this change is applied I believe we'll have to update dockerhub, though I'll defer to people who know more about docker/dockerhub than myself for that 😄 .